### PR TITLE
Fix links for updated repository name

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,4 +1,3 @@
-
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge
@@ -60,8 +59,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-[INSERT CONTACT METHOD].
+reported to the community leaders responsible for enforcement.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Every little bit helps, and credit will always be given.
 
 ### Report Bugs
 
-Report bugs at https://github.com/CodeToCommunicate/CoCoTerm1/issues.
+Report bugs at https://github.com/CodeToCommunicate/CoCoLessons/issues.
 
 If you are reporting a bug, please include:
 
@@ -28,7 +28,7 @@ implement it.
 ### Submit Feedback
 
 The best way to send feedback is to file an issue at
-https://github.com/CodeToCommunicate/CoCoTerm1/issues.
+https://github.com/CodeToCommunicate/CoCoLessons/issues.
 
 If you are proposing a feature:
 
@@ -43,7 +43,7 @@ Ready to contribute? Here's how to set up CoCo for local development.
 1.  Clone your fork locally:
 
     ```
-    $ git clone git@github.com:your_github_handle/CoCoTerm1.git
+    $ git clone git@github.com:your_github_handle/CoCoLessons.git
     ```
 
 1.  Create a branch for local development:

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -13,10 +13,3 @@ Contributors
 * Isamar Cort&eacute;s
 * Agustina Pesce
 * Mark Piper
-
-Acknowledgments
----------------
-
-This work is supported by the National Science Foundation under Award No.
-[2118272](https://www.nsf.gov/awardsearch/showAward?AWD_ID=2118272),
-*Collaborative Research: CyberTraining: Pilot: A Cybertraining Program to Advance Knowledge and Equity in the Geosciences*.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ under Award Nos. [2118272][nsf-award-nicole], [2117519][nsf-award-julie], and [2
 [cc-by-image]: https://i.creativecommons.org/l/by/4.0/88x31.png
 [csdms]: https://csdms.colorado.edu
 [jhub]: https://lab.openearthscape.org
-[nbgitpuller-link]: https://lab.openearthscape.org/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FCodeToCommunicate%2FCoCoTerm1&urlpath=lab%2Ftree%2FCoCoTerm1%2F%3Fautodecode&branch=main
+[nbgitpuller-link]: https://lab.openearthscape.org/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2FCodeToCommunicate%2FCoCoLessons&urlpath=lab%2Ftree%2FCoCoLessons%2F%3Fautodecode&branch=main
 [notebook]: ./lessons/jupyter/general_jupyter_notebook_tutorial.ipynb
 [nsf-award-nicole]: https://www.nsf.gov/awardsearch/showAward?AWD_ID=2118272
 [nsf-award-julie]: https://www.nsf.gov/awardsearch/showAward?AWD_ID=2117519


### PR DESCRIPTION
This PR fixes a few links that were broken when I changed the repo name from "CoCoTerm1" to "CoCoLessons".

One additional change: I removed the funding acknowledgment from CREDITS since it's already in README.