### PR TITLE
Rename environment.yaml to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 # A conda environment for CoCo coding sessions.
 #
 # Usage:
-#   $ conda env create --file=environment.yaml
+#   $ conda env create --file=environment.yml
 #   $ source activate coco
 
 name: coco


### PR DESCRIPTION
Change the file extension of the file to the one that is supported by `conda`.
Using `.yml` allows us to set up the environment even without the need
to pass the actual file to `conda`, like:
```
conda env create .
```